### PR TITLE
Improve file encoding handling in CachedFile class

### DIFF
--- a/src/python/autotransform/util/cachedfile.py
+++ b/src/python/autotransform/util/cachedfile.py
@@ -50,9 +50,7 @@ class CachedFile:
             str: The content of the file.
         """
 
-        # pylint: disable=unspecified-encoding
-
-        with open(path, "r") as file:
+        with open(path, "r", encoding="utf-8") as file:
             content = file.read()
         return content
 
@@ -78,9 +76,7 @@ class CachedFile:
             content (str): The content to write to the file.
         """
 
-        # pylint: disable=unspecified-encoding
-
-        with open(path, "w") as file:
+        with open(path, "w", encoding="utf-8") as file:
             file.write(content)
             file.flush()
 
@@ -90,8 +86,6 @@ class CachedFile:
         Args:
             new_content (str): The content to put in the file.
         """
-
-        # pylint: disable=unspecified-encoding
 
         self._write(self.path, new_content)
         FILE_CACHE[self.path] = new_content


### PR DESCRIPTION
The current implementation of the CachedFile class in the `cachedfile.py` file does not specify the encoding when reading and writing files, which can lead to issues with different file encodings. This commit specifies the encoding as utf-8 when reading and writing files to ensure consistent behavior across different systems and file types.