### PR TITLE
Improve error handling in JenkinsAPIRunner

### DIFF
--- a/src/python/autotransform/runner/jenkins.py
+++ b/src/python/autotransform/runner/jenkins.py
@@ -132,12 +132,12 @@ class JenkinsAPIRunner(Runner):
 
         try:
             auth = (jenkins_user, jenkins_token)
-            crumb = _fetch_jenkins_crumb(config.jenkins_base_url, auth)
+            crumb = JenkinsAPIRunner._fetch_jenkins_crumb(config.jenkins_base_url, auth)
             if crumb is None:
                 event_handler.handle(WarningEvent({"message": "Couldn't fetch Jenkins-Crumb"}))
                 return
 
-            response = _trigger_jenkins_job(config.jenkins_base_url, job_name, auth, params, crumb)
+            response = JenkinsAPIRunner._trigger_jenkins_job(config.jenkins_base_url, job_name, auth, params, crumb)
             if response.status_code == 201:
                 event_handler.handle(VerboseEvent({"message": "Jenkins job is triggered"}))
             else:

--- a/src/python/autotransform/runner/jenkins.py
+++ b/src/python/autotransform/runner/jenkins.py
@@ -39,12 +39,15 @@ class JenkinsAPIRunner(Runner):
     name: ClassVar[RunnerName] = RunnerName.JENKINS_API
 
     @staticmethod
-    def _fetch_jenkins_crumb(base_url: str, auth: Tuple[str, str]) -> Optional[str]:
+    def _fetch_jenkins_crumb(
+        base_url: str, auth: Tuple[str, str]
+    ) -> Optional[str]:
         """Fetches the Jenkins crumb which is required for CSRF protection.
 
         Args:
             base_url (str): The base URL of the Jenkins server.
-            auth (Tuple[str, str]): The username and token for Jenkins authentication.
+            auth (Tuple[str, str]): The username and token for Jenkins
+            authentication.
 
         Returns:
             Optional[str]: The Jenkins crumb if successful, None otherwise.
@@ -60,13 +63,20 @@ class JenkinsAPIRunner(Runner):
         return None
 
     @staticmethod
-    def _trigger_jenkins_job(base_url: str, job_name: str, auth: Tuple[str, str], params: Dict[str, Any], crumb: str) -> requests.Response:
+    def _trigger_jenkins_job(
+        base_url: str,
+        job_name: str,
+        auth: Tuple[str, str],
+        params: Dict[str, Any],
+        crumb: str,
+    ) -> requests.Response:
         """Triggers a Jenkins job.
 
         Args:
             base_url (str): The base URL of the Jenkins server.
             job_name (str): The name of the Jenkins job to trigger.
-            auth (Tuple[str, str]): The username and token for Jenkins authentication.
+            auth (Tuple[str, str]): The username and token for Jenkins
+              authentication.
             params (Dict[str, Any]): The params to pass to the Jenkins job.
             crumb (str): The Jenkins crumb for CSRF protection.
 
@@ -91,10 +101,15 @@ class JenkinsAPIRunner(Runner):
             schema (AutoTransformSchema): The schema that will be run.
         """
 
-        job_params = {"COMMAND": "run", "SCHEMA_NAME": schema.config.schema_name}
+        job_params = {
+            "COMMAND": "run",
+            "SCHEMA_NAME": schema.config.schema_name,
+        }
         if schema.config.max_submissions:
             job_params["MAX_SUBMISSIONS"] = str(schema.config.max_submissions)
-        shard_filter = [filt for filt in schema.filters if isinstance(filt, ShardFilter)]
+        shard_filter = [
+            filt for filt in schema.filters if isinstance(filt, ShardFilter)
+        ]
         if shard_filter:
             job_params["FILTER"] = json.dumps(shard_filter[0].bundle())
 
@@ -108,7 +123,11 @@ class JenkinsAPIRunner(Runner):
         """
 
         self._run_jenkins_job(
-            self.job_name, {"COMMAND": "update", "CHANGE": json.dumps(change.bundle())}
+            self.job_name,
+            {
+                "COMMAND": "update",
+                "CHANGE": json.dumps(change.bundle()),
+            },
         )
 
     @staticmethod
@@ -126,30 +145,58 @@ class JenkinsAPIRunner(Runner):
         jenkins_token = config.jenkins_token
         if jenkins_user is None or jenkins_token is None:
             event_handler.handle(
-                WarningEvent({"message": "User and token must be provided to use Jenkins"})
+                WarningEvent(
+                    {
+                        "message": "User and token must \
+                          be provided to use Jenkins"
+                    }
+                )
             )
             return
 
         try:
             auth = (jenkins_user, jenkins_token)
             if config.jenkins_base_url is None:
-              event_handler.handle(WarningEvent({"message": "Jenkins base URL is not configured"}))
-              return
-            crumb = JenkinsAPIRunner._fetch_jenkins_crumb(config.jenkins_base_url, auth)
-            if crumb is None:
-                event_handler.handle(WarningEvent({"message": "Couldn't fetch Jenkins-Crumb"}))
+                event_handler.handle(
+                    WarningEvent(
+                        {"message": "Jenkins base URL is not configured"}
+                    )
+                )
                 return
-            response = JenkinsAPIRunner._trigger_jenkins_job(config.jenkins_base_url, job_name, auth, params, crumb)
+            crumb = JenkinsAPIRunner._fetch_jenkins_crumb(
+                config.jenkins_base_url, auth
+            )
+            if crumb is None:
+                event_handler.handle(
+                    WarningEvent({"message": "Couldn't fetch Jenkins-Crumb"})
+                )
+                return
+            response = JenkinsAPIRunner._trigger_jenkins_job(
+                config.jenkins_base_url,
+                job_name,
+                auth,
+                params,
+                crumb,
+            )
             if response.status_code == 201:
-                event_handler.handle(VerboseEvent({"message": "Jenkins job is triggered"}))
+                event_handler.handle(
+                    VerboseEvent({"message": "Jenkins job is triggered"})
+                )
             else:
                 event_handler.handle(
-                    WarningEvent({"message": f"Failed to trigger the Jenkins job. Response code: {response.status_code}"})
+                    WarningEvent(
+                        {
+                            "message": f"Failed to trigger the Jenkins job.\
+                            Response code: {response.status_code}"
+                        }
+                    )
                 )
 
         # pylint: disable=broad-except
         except Exception as ex:
-            event_handler.handle(WarningEvent({"message": "Failed triggering the Jenkins job"}))
+            event_handler.handle(
+                WarningEvent({"message": "Failed triggering the Jenkins job"})
+            )
             event_handler.handle(WarningEvent({"message": f"Error: {str(ex)}"}))
 
 
@@ -166,16 +213,22 @@ class JenkinsFileRunner(Runner):
     num_files: ClassVar[int] = 0
 
     def run(self, schema: AutoTransformSchema) -> None:
-        """Triggers a full run of a Schema by creating a file with the appropriate content.
+        """Triggers a full run of a Schema by creating a file with
+        the appropriate content.
 
         Args:
             schema (AutoTransformSchema): The schema that will be run.
         """
 
-        job_params = {"COMMAND": "run", "SCHEMA_NAME": schema.config.schema_name}
+        job_params = {
+            "COMMAND": "run",
+            "SCHEMA_NAME": schema.config.schema_name,
+        }
         if schema.config.max_submissions:
             job_params["MAX_SUBMISSIONS"] = str(schema.config.max_submissions)
-        shard_filter = [filt for filt in schema.filters if isinstance(filt, ShardFilter)]
+        shard_filter = [
+            filt for filt in schema.filters if isinstance(filt, ShardFilter)
+        ]
         if shard_filter:
             job_params["FILTER"] = json.dumps(shard_filter[0].bundle())
 
@@ -188,7 +241,12 @@ class JenkinsFileRunner(Runner):
             change (Change): The Change to update.
         """
 
-        self._create_file({"COMMAND": "update", "CHANGE": json.dumps(change.bundle())})
+        self._create_file(
+            {
+                "COMMAND": "update",
+                "CHANGE": json.dumps(change.bundle()),
+            }
+        )
 
     def _create_file(self, props: Dict[str, str]) -> None:
         """Creates the file for the Jenkins job.
@@ -200,7 +258,9 @@ class JenkinsFileRunner(Runner):
         JenkinsFileRunner.num_files += 1
 
         cwd = os.getcwd().replace("\\", "/")
-        file_path = f"{cwd}/autotransform/jenkins/job_{JenkinsFileRunner.num_files}.txt"
+        file_path = (
+            f"{cwd}/autotransform/jenkins/job_{JenkinsFileRunner.num_files}.txt"
+        )
 
         os.makedirs(os.path.dirname(file_path), exist_ok=True)
         content = "\n".join([f"{k}={v}" for k, v in props.items()])

--- a/src/python/autotransform/runner/jenkins.py
+++ b/src/python/autotransform/runner/jenkins.py
@@ -132,11 +132,13 @@ class JenkinsAPIRunner(Runner):
 
         try:
             auth = (jenkins_user, jenkins_token)
+            if config.jenkins_base_url is None:
+              event_handler.handle(WarningEvent({"message": "Jenkins base URL is not configured"}))
+              return
             crumb = JenkinsAPIRunner._fetch_jenkins_crumb(config.jenkins_base_url, auth)
             if crumb is None:
                 event_handler.handle(WarningEvent({"message": "Couldn't fetch Jenkins-Crumb"}))
                 return
-
             response = JenkinsAPIRunner._trigger_jenkins_job(config.jenkins_base_url, job_name, auth, params, crumb)
             if response.status_code == 201:
                 event_handler.handle(VerboseEvent({"message": "Jenkins job is triggered"}))


### PR DESCRIPTION
Refactor the JenkinsAPIRunner class to improve error handling and readability. Specifically, separate the logic for fetching the Jenkins crumb and triggering the Jenkins job into separate methods. This will make the code easier to read and maintain. Additionally, add more detailed error messages to help with debugging in case of failures.